### PR TITLE
Potential fix for code scanning alert no. 2: Shell command built from environment values

### DIFF
--- a/scripts/merge-coverage.js
+++ b/scripts/merge-coverage.js
@@ -102,11 +102,21 @@ function mergeCoverage() {
 // Generate merged report
 function generateReport() {
   console.log('📊 Generating merged coverage report...');
-  
-  const reportCommand = `npx nyc report --reporter=html --reporter=text --reporter=lcov --report-dir=${MERGED_COVERAGE} --temp-dir=${MERGED_COVERAGE}`;
-  
+
+  // Use execFileSync to safely pass arguments without shell interpretation
+  const execFileSync = require('child_process').execFileSync;
+  const args = [
+    'nyc',
+    'report',
+    '--reporter=html',
+    '--reporter=text',
+    '--reporter=lcov',
+    `--report-dir=${MERGED_COVERAGE}`,
+    `--temp-dir=${MERGED_COVERAGE}`
+  ];
+
   try {
-    execSync(reportCommand, { stdio: 'inherit' });
+    execFileSync('npx', args, { stdio: 'inherit' });
     console.log('✅ Merged coverage report generated at:', MERGED_COVERAGE);
     return true;
   } catch (error) {


### PR DESCRIPTION
Potential fix for [https://github.com/dock108/mini-golf-break/security/code-scanning/2](https://github.com/dock108/mini-golf-break/security/code-scanning/2)

To fix this problem, we should avoid constructing shell commands as strings that include environment-controlled values (such as directory paths) and then executing them with `execSync`, which invokes a shell and is susceptible to shell injection and misinterpretation of spaces or special characters. Instead, we should use `execFileSync` from the `child_process` module, which allows us to specify the command and its arguments as separate parameters, bypassing the shell entirely. This eliminates the risk of shell injection and ensures that arguments are passed safely.

Specifically, in `generateReport()`, rather than constructing `reportCommand` as a string and passing it to `execSync`, we should split the command into the executable (`npx`) and its arguments (`nyc`, `report`, etc.), passing the dynamic paths as elements of the arguments array. This change affects lines 106-109 in `scripts/merge-coverage.js`. No other changes are required elsewhere in the file.

No new imports are needed, as `execFileSync` is already available from `child_process`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
